### PR TITLE
Fixed bug in Grid::nodeCoords

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -202,9 +202,8 @@ void Grid::updateNode(int id) const {
 
 const IRect Grid::nodeCoords(const FBox &box) const {
 	auto pmin = worldToGrid(vmax(int2(0, 0), int2(box.x(), box.z())));
-	auto pmax = vmin(m_size - int2(1, 1),
-					 worldToGrid(int2(box.ex() - big_epsilon, box.ez() - big_epsilon)));
-	pmax = vmax(pmin, pmax);
+	auto pmax = worldToGrid(int2(box.ex() - big_epsilon, box.ez() - big_epsilon));
+	pmax = vmin(vmax(pmin, pmax), m_size - int2(1, 1));
 	return IRect(pmin, pmax);
 }
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -128,7 +128,11 @@ class Grid {
 		return p.x >= 0 && p.y >= 0 && p.x < m_size.x && p.y < m_size.y;
 	}
 
-	int nodeAt(const int2 &grid_pos) const { return grid_pos.x + grid_pos.y * m_size.x; }
+	int nodeAt(const int2 &grid_pos) const {
+		PASSERT(isInsideGrid(grid_pos));
+		return grid_pos.x + grid_pos.y * m_size.x;
+	}
+
 	void updateNode(int node_id) const __attribute((noinline));
 	void updateNode(int node_id, const ObjectDef &) const __attribute((noinline));
 	int extractObjects(int node_id, const Object **out, int ignored_id = -1, int flags = 0) const;


### PR DESCRIPTION
Sometimes nodeCoords returned coordinates which were outside the grid.